### PR TITLE
Adding ability to write diff artifacts to disk

### DIFF
--- a/Sources/SnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertInlineSnapshot.swift
@@ -144,7 +144,13 @@ public func _verifyInlineSnapshot<Value>(
         if ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS") {
           XCTContext.runActivity(named: "Attached Failure Diff") { activity in
             attachments.forEach {
-              activity.add($0)
+              let data = snapshotting.diffing.toData($0.value)
+              let attachment = XCTAttachment(
+                data: data,
+                uniformTypeIdentifier: $0.uniformTypeIdentifier
+              )
+              attachment.name = $0.name
+              activity.add(attachment)
             }
           }
         }

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -190,8 +190,9 @@ public func verifySnapshot<Value, Format>(
       }
 
       let testName = sanitizePathComponent(testName)
+      let snapshotFileName = "\(testName).\(identifier)"
       let snapshotFileUrl = snapshotDirectoryUrl
-        .appendingPathComponent("\(testName).\(identifier)")
+        .appendingPathComponent(snapshotFileName)
         .appendingPathExtension(snapshotting.pathExtension ?? "")
       let fileManager = FileManager.default
       try fileManager.createDirectory(at: snapshotDirectoryUrl, withIntermediateDirectories: true)
@@ -248,20 +249,37 @@ public func verifySnapshot<Value, Format>(
         fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory(), isDirectory: true
       )
       let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
-      try fileManager.createDirectory(at: artifactsSubUrl, withIntermediateDirectories: true)
       let failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
-      try snapshotting.diffing.toData(diffable).write(to: failedSnapshotFileUrl)
+      try fileManager.createDirectory(at: artifactsSubUrl, withIntermediateDirectories: true)
 
       if !attachments.isEmpty {
         #if !os(Linux)
         if ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS") {
           XCTContext.runActivity(named: "Attached Failure Diff") { activity in
             attachments.forEach {
-              activity.add($0)
+              let data = snapshotting.diffing.toData($0.value)
+              let attachment = XCTAttachment(
+                data: data,
+                uniformTypeIdentifier: $0.uniformTypeIdentifier
+              )
+              attachment.name = $0.name
+              activity.add(attachment)
             }
           }
         }
         #endif
+
+        for (index, attachment) in attachments.enumerated() {
+          let snapshotArtifactUrl = artifactsSubUrl.appendingPathComponent(snapshotFileName)
+          try fileManager.createDirectory(at: snapshotArtifactUrl, withIntermediateDirectories: true)
+
+          let snapshotArtifactFileUrl = snapshotArtifactUrl
+            .appendingPathComponent(attachment.name ?? String(describing: index))
+            .appendingPathExtension(snapshotting.pathExtension ?? "")
+          try snapshotting.diffing.toData(attachment.value).write(to: snapshotArtifactFileUrl)
+        }
+      } else {
+        try snapshotting.diffing.toData(diffable).write(to: failedSnapshotFileUrl)
       }
 
       let diffMessage = diffTool

--- a/Sources/SnapshotTesting/Diffing.swift
+++ b/Sources/SnapshotTesting/Diffing.swift
@@ -10,7 +10,7 @@ public struct Diffing<Value> {
   public var fromData: (Data) -> Value
 
   /// Compares two values. If the values do not match, returns a failure message and artifacts describing the failure.
-  public var diff: (Value, Value) -> (String, [XCTAttachment])?
+  public var diff: (Value, Value) -> (String, [DiffingArtifact<Value>])?
 
   /// Creates a new `Diffing` on `Value`.
   ///
@@ -25,10 +25,38 @@ public struct Diffing<Value> {
   public init(
     toData: @escaping (_ value: Value) -> Data,
     fromData: @escaping (_ data: Data) -> Value,
-    diff: @escaping (_ lhs: Value, _ rhs: Value) -> (String, [XCTAttachment])?
+    diff: @escaping (_ lhs: Value, _ rhs: Value) -> (String, [DiffingArtifact<Value>])?
     ) {
     self.toData = toData
     self.fromData = fromData
     self.diff = diff
   }
+}
+
+public struct DiffingArtifact<Value> {
+    /// The name of artifact type, i.e. "reference", "failure", "patch", etc.
+    public var name: String?
+    
+    /// UTI (Uniform Type Identifier) of the payload data for an `XCTAttachment`.
+    public var uniformTypeIdentifier: String
+    
+    /// The value of the artifact.
+    public var value: Value
+    
+    /// Creates a new `DiffingArtifact` on `Value`.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the artifact, to be written to disk and included
+    ///   as an `XCTAttachment`.
+    ///   - uniformTypeIdentifier: UTI for `XCTAttachment` payload representing the artifact.
+    ///   - value: The value to be written to disk and included as an `XCTAttachment` payload.
+    public init(
+        name: String? = nil,
+        uniformTypeIdentifier: String,
+        value: Value
+    ) {
+        self.name = name
+        self.uniformTypeIdentifier = uniformTypeIdentifier
+        self.value = value
+    }
 }

--- a/Sources/SnapshotTesting/Snapshotting/String.swift
+++ b/Sources/SnapshotTesting/Snapshotting/String.swift
@@ -20,7 +20,10 @@ extension Diffing where Value == String {
     let failure = hunks
       .flatMap { [$0.patchMark] + $0.lines }
       .joined(separator: "\n")
-    let attachment = XCTAttachment(data: Data(failure.utf8), uniformTypeIdentifier: "public.patch-file")
-    return (failure, [attachment])
+    let artifact = DiffingArtifact(
+      uniformTypeIdentifier: "public.patch-file",
+      value: failure
+    )
+    return (failure, [artifact])
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -20,15 +20,24 @@ extension Diffing where Value == UIImage {
       let message = new.size == old.size
         ? "Newly-taken snapshot does not match reference."
         : "Newly-taken snapshot@\(new.size) does not match reference@\(old.size)."
-      let oldAttachment = XCTAttachment(image: old)
-      oldAttachment.name = "reference"
-      let newAttachment = XCTAttachment(image: new)
-      newAttachment.name = "failure"
-      let differenceAttachment = XCTAttachment(image: difference)
-      differenceAttachment.name = "difference"
+      let oldArtifact = DiffingArtifact(
+        name: "reference",
+        uniformTypeIdentifier: "public.png",
+        value: old
+      )
+      let newArtifact = DiffingArtifact(
+        name: "failure",
+        uniformTypeIdentifier: "public.png",
+        value: new
+      )
+      let diffArtifact = DiffingArtifact(
+        name: "difference",
+        uniformTypeIdentifier: "public.png",
+        value: difference
+      )
       return (
         message,
-        [oldAttachment, newAttachment, differenceAttachment]
+        [oldArtifact, newArtifact, diffArtifact]
       )
     }
   }


### PR DESCRIPTION
Currently the snapshot testing framework only uses the diffing artifacts as XCTAttachments. When snapshotting images, it would be useful if these artifacts were written to disk and not disposed of for these reasons:
- When trying to view the difference between the reference and result, the diff image provides a much clearer representation of where it failed, particularly when the reference and result are very similar
- We can see all the results once all tests have run, without having to add a breakpoint at every failing test to inspect the resulting image
- Writing to disk will appear in our uncommitted changes in github, and therefore will be more discoverable 
- If builds pass locally but not on CI, we can go to that agent to inspect the images, as they're not thrown away